### PR TITLE
add klarna to lay offs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To follow the signal through the media noise, I have started to collect all the 
 * Gopuff
 * Gorilla
 * Hopin
+* klarna
 * Latch
 * MainStreet
 * Mural


### PR DESCRIPTION
They laid off 700 ppl two weeks ago

Edit:  [source](https://techcrunch.com/2022/05/23/klarna-lays-off-10-of-its-workforce/) 